### PR TITLE
Add multiasset support

### DIFF
--- a/app/css/index.css
+++ b/app/css/index.css
@@ -744,6 +744,10 @@ video {
 	border-color: rgb(148 163 184 / 0.3);
 }
 
+.border-white\/30 {
+	border-color: rgb(255 255 255 / 0.3);
+}
+
 .border-white\/50 {
 	border-color: rgb(255 255 255 / 0.5);
 }
@@ -785,6 +789,10 @@ video {
 
 .bg-white\/20 {
 	background-color: rgb(255 255 255 / 0.2);
+}
+
+.bg-white\/5 {
+	background-color: rgb(255 255 255 / 0.05);
 }
 
 .p-2 {
@@ -905,6 +913,10 @@ video {
 	outline-offset: 2px;
 }
 
+.filter {
+	filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
 .placeholder\:text-gray-600::-moz-placeholder {
 	--tw-text-opacity: 1;
 	color: rgb(75 85 99 / var(--tw-text-opacity));
@@ -950,8 +962,17 @@ video {
 	border-color: rgb(255 255 255 / var(--tw-border-opacity));
 }
 
+.focus\:border-white\/20:focus {
+	border-color: rgb(255 255 255 / 0.2);
+}
+
 .focus\:border-white\/90:focus {
 	border-color: rgb(255 255 255 / 0.9);
+}
+
+.focus\:bg-black:focus {
+	--tw-bg-opacity: 1;
+	background-color: rgb(0 0 0 / var(--tw-bg-opacity));
 }
 
 .focus\:bg-white\/20:focus {

--- a/app/ts/components/Button.tsx
+++ b/app/ts/components/Button.tsx
@@ -1,5 +1,6 @@
 const classNames = {
 	primary: 'h-12 px-4 border border-white/50 bg-white/20 outline-none focus:border-white/90 focus:bg-white/20',
+	secondary: 'h-12 px-4 border border-white/30 bg-white/5 outline-none focus:border-white/20 focus:bg-black',
 	full: 'px-4 h-16 border border-white/50 text-lg bg-white/10 flex items-center gap-2 justify-center outline-none focus:border-white/90 focus:bg-white/20 disabled:opacity-50'
 }
 
@@ -11,7 +12,7 @@ export const Button = ({
 }: {
 	children: string
 	disabled?: boolean
-	variant?: 'primary' | 'full'
+	variant?: 'primary' | 'secondary' | 'full'
 	onClick: () => unknown
 }) => {
 	return (

--- a/app/ts/components/Transfer.tsx
+++ b/app/ts/components/Transfer.tsx
@@ -11,10 +11,12 @@ import { ItemDetails } from './ItemDetails.js'
 import { EthereumAddress } from '../types/ethereumTypes.js'
 import { serialize } from '../types/wireTypes.js'
 
+type SupportedToken = ERC721 | ERC1155
+
 export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderStore | undefined>, blockInfo: Signal<BlockInfo> }) => {
 	const selectedNft = useSignal<ERC721 | ERC1155 | undefined>(undefined)
+	const selectedMultiAssets = useSignal<{ assets: (ERC721 | ERC1155)[] , displayIndex: number }>({ assets: [], displayIndex: 0 })
 
-	// 'notfound' | 'badid' | 'noprovider' | 'EOA' | 'contract' | 'ERC20' | 'opensea'
 	const fetchingStates = useSignal<'empty' | 'fetching' | 'complete'>('empty')
 
 	const sendText = useComputed(() => {
@@ -25,18 +27,6 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 	})
 
 	const warning = useSignal<string | undefined>(undefined)
-
-	// const errorMessages: { [error: string]: string } = {
-	// 	notfound: 'No NFT found at address',
-	// 	contract: 'No NFT found at address',
-	// 	badid: 'Found NFT collection, but token ID does not exist',
-	// 	noprovider: 'Connect wallet to load token details.',
-	// 	EOA: 'Token address provided is an EOA',
-	// 	ERC20: 'Token address provided is an ERC20 contract',
-	// 	// if ('owner' in selectedNft.value && selectedNft.value.owner !== provider.value?.walletAddress) return 'You do not own this token'
-	// 	// if (recipient.value === provider.value?.walletAddress) return 'Cannot send to yourself'
-	// 	// if (recipient.value === selectedNft.value.address) return 'Cannot send to the NFT contract'
-	// }
 
 	const contractAddressInput = useSignal<string>('')
 	const recipientInput = useSignal<string>('')
@@ -129,14 +119,14 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 		}
 		fetchingStates.value = 'fetching'
 		try {
-			const identifiedAddress = await itentifyAddress(address, id, provider.value?.provider, provider.value?.walletAddress)
-			if (identifiedAddress.address === contractAddress.value && identifiedAddress.inputId === itemId.value) {
-				if (identifiedAddress.type === 'ERC721') {
-					selectedNft.value = identifiedAddress
-				} else if (identifiedAddress.type === 'ERC1155') {
-					selectedNft.value = identifiedAddress
-				} else if (identifiedAddress.type === 'ERC20') {
-					warning.value = 'Token address provided is an ERC20 contract'
+			const identifiedAssets = await itentifyAddress(address, id, provider.value?.provider, provider.value?.walletAddress)
+			if (identifiedAssets[0].address === contractAddress.value && identifiedAssets[0].inputId === itemId.value) {
+				const supportedTypes = identifiedAssets.filter((token) => ['ERC721', 'ERC1155'].includes(token.type)) as SupportedToken[]
+				if (supportedTypes.length === 0) warning.value = identifiedAssets[0].type === 'ERC20' ? 'Token address provided is an ERC20 contract' : 'Token address provided is an EOA'
+				else {
+					selectedNft.value = supportedTypes[0]
+					if (supportedTypes.length > 1) selectedMultiAssets.value = { displayIndex: selectedMultiAssets.peek().displayIndex >= supportedTypes.length ? 0 : selectedMultiAssets.peek().displayIndex, assets: supportedTypes }
+					else selectedMultiAssets.value = { displayIndex: selectedMultiAssets.value.displayIndex, assets: [] }
 				}
 			}
 		} catch (e) {
@@ -161,6 +151,19 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 				<TextInput warn={showWarn.value.contract} value={contractAddressInput} size='w-full' label='Contract Address' placeholder='0x133...789 or OpenSea Item URL https://opensea.io/assets/...' />
 				<NumberInput warn={showWarn.value.id} label='Token ID' placeholder='1' value={idInput} />
 			</div>
+			{selectedMultiAssets.value.assets.length > 0 ?
+			<div className='flex items-center gap-2'>
+				<div>
+					<h3 className='text-md font-semibold'>Multiple NFT Types Detected</h3>
+					<p className='text-sm'>Select Target NFT Type</p>
+				</div>
+				{selectedMultiAssets.value.assets.map((asset, index) =>
+					<Button variant={index === selectedMultiAssets.value.displayIndex ? 'primary' : 'secondary'} onClick={() => batch(() => {
+						selectedMultiAssets.value = { ...selectedMultiAssets.peek(), displayIndex: index }
+						selectedNft.value = asset
+					})}>{asset.type}</Button>
+				)}
+			</div> : null}
 			{selectedNft.value?.type === 'ERC1155' ?
 				<div className='flex gap-4 flex-col sm:flex-row'>
 					<TokenAmountInput balance={selectedNft.value.balance} value={transferAmountInput} warn={showWarn.value.amount} label='Transfer Amount' size='w-full' placeholder='1' />

--- a/app/ts/components/Transfer.tsx
+++ b/app/ts/components/Transfer.tsx
@@ -1,7 +1,7 @@
 import { batch, Signal, useComputed, useSignal, useSignalEffect } from '@preact/signals'
 import { getAddress } from 'ethers'
 import { connectBrowserProvider, ProviderStore } from '../library/provider.js'
-import { itentifyAddress, ERC721, ERC1155 } from '../library/identifyTokens.js'
+import { itentifyAddress, ERC721, ERC1155, SupportedToken } from '../library/identifyTokens.js'
 import { BlockInfo } from '../library/types.js'
 import { Button } from './Button.js'
 import { transferERC1155, transferERC721 } from '../library/transactions.js'
@@ -10,8 +10,6 @@ import { BlockieTextInput, NumberInput, TextInput, TokenAmountInput } from './In
 import { ItemDetails } from './ItemDetails.js'
 import { EthereumAddress } from '../types/ethereumTypes.js'
 import { serialize } from '../types/wireTypes.js'
-
-type SupportedToken = ERC721 | ERC1155
 
 export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderStore | undefined>, blockInfo: Signal<BlockInfo> }) => {
 	const selectedNft = useSignal<ERC721 | ERC1155 | undefined>(undefined)
@@ -121,7 +119,7 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 		try {
 			const identifiedAssets = await itentifyAddress(address, id, provider.value?.provider, provider.value?.walletAddress)
 			if (identifiedAssets[0].address === contractAddress.value && identifiedAssets[0].inputId === itemId.value) {
-				const supportedTypes = identifiedAssets.filter((token) => ['ERC721', 'ERC1155'].includes(token.type)) as SupportedToken[]
+				const supportedTypes = identifiedAssets.filter((token): token is SupportedToken => ['ERC721', 'ERC1155'].includes(token.type))
 				if (supportedTypes.length === 0) warning.value = identifiedAssets[0].type === 'ERC20' ? 'Token address provided is an ERC20 contract' : 'Token address provided is an EOA'
 				else {
 					selectedNft.value = supportedTypes[0]

--- a/app/ts/library/identifyTokens.ts
+++ b/app/ts/library/identifyTokens.ts
@@ -41,6 +41,8 @@ export type ERC1155 = {
 }
 
 export type IdentifiedAddress = (EOA | ERC20 | ERC721 | ERC1155 | UnknownContract) & { inputId: bigint }
+export type SupportedToken = (ERC721 | ERC1155) & { inputId: bigint }
+
 
 export async function itentifyAddress(address: string, id: bigint, provider: Provider, user: EthereumAddress): Promise<IdentifiedAddress[]> {
 	const contractCode = await provider.getCode(address)

--- a/app/ts/library/identifyTokens.ts
+++ b/app/ts/library/identifyTokens.ts
@@ -42,9 +42,9 @@ export type ERC1155 = {
 
 export type IdentifiedAddress = (EOA | ERC20 | ERC721 | ERC1155 | UnknownContract) & { inputId: bigint }
 
-export async function itentifyAddress(address: string, id: bigint, provider: Provider, user: EthereumAddress): Promise<IdentifiedAddress> {
+export async function itentifyAddress(address: string, id: bigint, provider: Provider, user: EthereumAddress): Promise<IdentifiedAddress[]> {
 	const contractCode = await provider.getCode(address)
-	if (contractCode === '0x') return { type: 'EOA', address, inputId: id }
+	if (contractCode === '0x') return [{ type: 'EOA', address, inputId: id }]
 
 	const multicall = new Contract('0x5ba1e12693dc8f9c48aad8770482f4739beed696', MulticallABI, provider)
 	const nftInterface = new Interface(ERC721ABI)
@@ -100,11 +100,11 @@ export async function itentifyAddress(address: string, id: bigint, provider: Pro
 
 	const [isERC721, hasMetadata, isERC1155, isERC1155Metadata, owner, name, symbol, decimals, totalSupply, tokenURI, erc1155Uri]: { success: boolean, returnData: BytesLike }[] = await multicall.tryAggregate.staticCall(false, calls)
 
-	try {
+	let matchingAssetTypes: IdentifiedAddress[] = []
 
-		if (isERC721.success && nftInterface.decodeFunctionResult('supportsInterface', isERC721.returnData)[0] === true) {
-			if (owner.success === false || nftInterface.decodeFunctionResult('ownerOf', owner.returnData)[0] === ZeroAddress) throw new Error('No ERC721 found at address')
-			return {
+	try {
+		if (isERC721.success && nftInterface.decodeFunctionResult('supportsInterface', isERC721.returnData)[0] === true && owner.success === false && nftInterface.decodeFunctionResult('ownerOf', owner.returnData)[0] === ZeroAddress) {
+			matchingAssetTypes.push({
 				type: 'ERC721',
 				inputId: id,
 				address,
@@ -112,26 +112,34 @@ export async function itentifyAddress(address: string, id: bigint, provider: Pro
 				owner: nftInterface.decodeFunctionResult('ownerOf', owner.returnData)[0],
 				name: hasMetadata.success ? nftInterface.decodeFunctionResult('name', name.returnData)[0] : undefined,
 				tokenURI: hasMetadata.success ? nftInterface.decodeFunctionResult('tokenURI', tokenURI.returnData)[0] : undefined,
-			}
+			})
 		}
+	} catch (error) {
+		console.error(error)
+	}
 
+	try {
 		if (isERC1155.success && nftInterface.decodeFunctionResult('supportsInterface', isERC1155.returnData)[0] === true) {
 			const tokenContract = new Contract(address, ERC1155ABI, provider)
 			const userAddress = serialize(EthereumAddress, user)
 			const balance = await tokenContract.balanceOf(userAddress, id)
 			const uri: string | undefined = erc1155Uri.success && isERC1155Metadata.success && erc1155Interface.decodeFunctionResult('supportsInterface', isERC1155Metadata.returnData)[0] === true ? erc1155Interface.decodeFunctionResult('uri', erc1155Uri.returnData)[0] : undefined
-			return {
+			matchingAssetTypes.push({
 				type: 'ERC1155',
 				inputId: id,
 				id,
 				address,
 				balance,
 				tokenURI: uri ? uri.replaceAll(`{id}`, id.toString(10)) : undefined,
-			}
+			})
 		}
+	} catch (error) {
+		console.error(error)
+	}
 
+	try {
 		if (name.success && decimals.success && symbol.success && totalSupply.success) {
-			return {
+			matchingAssetTypes.push({
 				type: 'ERC20',
 				inputId: id,
 				address,
@@ -139,15 +147,12 @@ export async function itentifyAddress(address: string, id: bigint, provider: Pro
 				symbol: erc20Interface.decodeFunctionResult('name', symbol.returnData)[0],
 				decimals: BigInt(erc20Interface.decodeFunctionResult('decimals', decimals.returnData)[0]),
 				totalSupply: erc20Interface.decodeFunctionResult('totalSupply', totalSupply.returnData)[0]
-			}
+			})
 		}
-
 	} catch (error) {
-		// For any reason decoding txing fails catch and return as unknown contract
 		console.error(error)
-		return { type: 'contract', address, inputId: id }
 	}
 
 	// If doesn't pass checks being an ERC20 or ERC721, then we only know its a contract
-	return { type: 'contract', address, inputId: id }
+	return matchingAssetTypes.length > 0 ? matchingAssetTypes : [{ type: 'contract', address, inputId: id }]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@preact/signals": "1.1.1",
 				"ether-state": "^0.2.0",
-				"ethers": "^6.3.0",
+				"ethers": "6.7.0",
 				"funtypes": "5.0.3",
 				"preact": "10.8.1"
 			},
@@ -20,9 +20,9 @@
 			}
 		},
 		"node_modules/@adraffy/ens-normalize": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz",
-			"integrity": "sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ=="
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
+			"integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg=="
 		},
 		"node_modules/@noble/hashes": {
 			"version": "1.1.2",
@@ -77,9 +77,9 @@
 			"dev": true
 		},
 		"node_modules/aes-js": {
-			"version": "4.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.3.tgz",
-			"integrity": "sha512-/xJX0/VTPcbc5xQE2VUP91y1xN8q/rDfhEzLm+vLc3hYvb5+qHCnpJRuFcrKn63zumK/sCwYYzhG8HP78JYSTA=="
+			"version": "4.0.0-beta.5",
+			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+			"integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
 		},
 		"node_modules/ether-state": {
 			"version": "0.2.0",
@@ -90,9 +90,9 @@
 			}
 		},
 		"node_modules/ethers": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-6.3.0.tgz",
-			"integrity": "sha512-CKFYvTne1YT4S1glTiu7TgGsj0t6c6GAD7evrIk8zbeUb6nK8dcUPAiAWM8uDX/1NmRTvLM9+1Vnn49hwKtEzw==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.0.tgz",
+			"integrity": "sha512-pxt5hK82RNwcTX2gOZP81t6qVPVspnkpeivwEgQuK9XUvbNtghBnT8GNIb/gPh+WnVSfi8cXC9XlfT8sqc6D6w==",
 			"funding": [
 				{
 					"type": "individual",
@@ -104,16 +104,22 @@
 				}
 			],
 			"dependencies": {
-				"@adraffy/ens-normalize": "1.9.0",
+				"@adraffy/ens-normalize": "1.9.2",
 				"@noble/hashes": "1.1.2",
 				"@noble/secp256k1": "1.7.1",
-				"aes-js": "4.0.0-beta.3",
+				"@types/node": "18.15.13",
+				"aes-js": "4.0.0-beta.5",
 				"tslib": "2.4.0",
 				"ws": "8.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/ethers/node_modules/@types/node": {
+			"version": "18.15.13",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+			"integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
 		},
 		"node_modules/funtypes": {
 			"version": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"dependencies": {
 		"@preact/signals": "1.1.1",
 		"ether-state": "^0.2.0",
-		"ethers": "^6.3.0",
+		"ethers": "6.7.0",
 		"funtypes": "5.0.3",
 		"preact": "10.8.1"
 	}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"type": "module",
 	"dependencies": {
 		"@preact/signals": "1.1.1",
-		"ether-state": "^0.2.0",
+		"ether-state": "0.2.0",
 		"ethers": "6.7.0",
 		"funtypes": "5.0.3",
 		"preact": "10.8.1"


### PR DESCRIPTION
- Add multiasset support
- Don't break false positive token types
- upgrade ehers to 6.7

Fixes #18

If a token does support multiple asset types, display a toggle, otherwise just show the one, like in the example of #18, we had a false positive of ERC721, when it was a 1155 and it broke the detection. 
![image](https://github.com/DarkFlorist/nft-wallet/assets/52896585/7ec13766-ad3a-4759-8278-343eeb11c091)
