### PR TITLE
Add Notice component and display error and sucess of transaction requ…

### DIFF
--- a/app/css/index.css
+++ b/app/css/index.css
@@ -723,12 +723,20 @@ video {
 	white-space: nowrap;
 }
 
+.break-all {
+	word-break: break-all;
+}
+
 .rounded {
 	border-radius: 0.25rem;
 }
 
 .border {
 	border-width: 1px;
+}
+
+.border-green-400\/50 {
+	border-color: rgb(74 222 128 / 0.5);
 }
 
 .border-orange-400\/50 {
@@ -738,6 +746,10 @@ video {
 .border-red-400 {
 	--tw-border-opacity: 1;
 	border-color: rgb(248 113 113 / var(--tw-border-opacity));
+}
+
+.border-red-400\/50 {
+	border-color: rgb(248 113 113 / 0.5);
 }
 
 .border-slate-400\/30 {
@@ -765,6 +777,10 @@ video {
 	background-color: rgb(0 0 0 / 0.9);
 }
 
+.bg-green-400\/10 {
+	background-color: rgb(74 222 128 / 0.1);
+}
+
 .bg-neutral-800 {
 	--tw-bg-opacity: 1;
 	background-color: rgb(38 38 38 / var(--tw-bg-opacity));
@@ -772,6 +788,10 @@ video {
 
 .bg-orange-400\/10 {
 	background-color: rgb(251 146 60 / 0.1);
+}
+
+.bg-red-400\/10 {
+	background-color: rgb(248 113 113 / 0.1);
 }
 
 .bg-transparent {
@@ -902,6 +922,10 @@ video {
 
 .text-white\/70 {
 	color: rgb(255 255 255 / 0.7);
+}
+
+.text-white\/75 {
+	color: rgb(255 255 255 / 0.75);
 }
 
 .outline-none {

--- a/app/ts/components/Notice.tsx
+++ b/app/ts/components/Notice.tsx
@@ -1,0 +1,22 @@
+import { JSX } from 'preact/jsx-runtime'
+
+export const SingleNotice = ({ variant, title, description }: { variant: 'warn' | 'error' | 'success', title: string, description?: string | JSX.Element }) => {
+	const variantColors = {
+		warn: 'border-orange-400/50 bg-orange-400/10',
+		error: 'border-red-400/50 bg-red-400/10',
+		success: 'border-green-400/50 bg-green-400/10'
+	}
+	const variantEmoji = {
+		warn: '⚠',
+		error: '🛑',
+		success: '🎉'
+	}
+
+	return (<div class={`flex items-center items-center border ${variantColors[variant]} px-4 py-2 gap-4`}>
+		<span class='text-2xl'>{variantEmoji[variant]}</span>
+		<div class='py-3 flex-grow'>
+			<h3 class='font-lg font-semibold'>{title}</h3>
+			{description ? (<div class='leading-tight text-white/75 break-all text-sm'>{description}</div>) : null}
+		</div>
+	</div>)
+}

--- a/app/ts/components/Transfer.tsx
+++ b/app/ts/components/Transfer.tsx
@@ -12,6 +12,7 @@ import { EthereumAddress } from '../types/ethereumTypes.js'
 import { serialize } from '../types/wireTypes.js'
 import { useAsyncState } from '../library/asyncState.js'
 import { SingleNotice } from './Notice.js'
+import { HumanReadableEthersError } from '../library/humanEthersErrors.js'
 
 export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderStore | undefined>, blockInfo: Signal<BlockInfo> }) => {
 	const selectedNft = useSignal<ERC721 | ERC1155 | undefined>(undefined)
@@ -150,7 +151,7 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 		}
 	}
 
-	const { value: transactionReceipt, waitFor: waitForTransaction } = useAsyncState<TransactionResponse>()
+	const { value: transactionReceipt, waitFor: waitForTransaction } = useAsyncState<TransactionResponse, HumanReadableEthersError>()
 
 	async function sendTransfer() {
 		if (!selectedNft.value || !recipientAddress.value || !provider.value) return
@@ -203,7 +204,7 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 				? <Button variant='full' disabled={sendText.value !== 'Send'} onClick={sendTransfer}>{sendText.value}</Button>
 				: <Button variant='full' onClick={() => connectBrowserProvider(provider, blockInfo)}>Connect Wallet</Button>
 			}
-			{transactionReceipt.value.state === 'rejected' ? <SingleNotice variant='error' description={transactionReceipt.value.error.message} title="Error Sending Transfer" /> : null}
+			{transactionReceipt.value.state === 'rejected' && transactionReceipt.value.error.warning ? <SingleNotice variant='error' description={transactionReceipt.value.error.message} title="Error Sending Transfer" /> : null}
 			{transactionReceipt.value.state === 'resolved' ? <SingleNotice variant='success' description={`Transaction Hash: ${transactionReceipt.value.value.hash}`} title="Tranaction Submitted" /> : null}
 		</div>
 	)

--- a/app/ts/components/Transfer.tsx
+++ b/app/ts/components/Transfer.tsx
@@ -12,7 +12,7 @@ import { EthereumAddress } from '../types/ethereumTypes.js'
 import { serialize } from '../types/wireTypes.js'
 import { useAsyncState } from '../library/asyncState.js'
 import { SingleNotice } from './Notice.js'
-import { HumanReadableEthersError } from '../library/humanEthersErrors.js'
+import { humanReadableEthersError } from '../library/humanEthersErrors.js'
 
 export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderStore | undefined>, blockInfo: Signal<BlockInfo> }) => {
 	const selectedNft = useSignal<ERC721 | ERC1155 | undefined>(undefined)
@@ -151,7 +151,7 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 		}
 	}
 
-	const { value: transactionReceipt, waitFor: waitForTransaction } = useAsyncState<TransactionResponse, HumanReadableEthersError>()
+	const { value: transactionReceipt, waitFor: waitForTransaction } = useAsyncState<TransactionResponse>()
 
 	async function sendTransfer() {
 		if (!selectedNft.value || !recipientAddress.value || !provider.value) return
@@ -204,7 +204,7 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 				? <Button variant='full' disabled={sendText.value !== 'Send'} onClick={sendTransfer}>{sendText.value}</Button>
 				: <Button variant='full' onClick={() => connectBrowserProvider(provider, blockInfo)}>Connect Wallet</Button>
 			}
-			{transactionReceipt.value.state === 'rejected' && transactionReceipt.value.error.warning ? <SingleNotice variant='error' description={transactionReceipt.value.error.message} title='Error Sending Transfer' /> : null}
+			{transactionReceipt.value.state === 'rejected' && humanReadableEthersError(transactionReceipt.value.error).warning ? <SingleNotice variant='error' description={humanReadableEthersError(transactionReceipt.value.error).message} title='Error Sending Transfer' /> : null}
 			{transactionReceipt.value.state === 'resolved' ? <SingleNotice variant='success' description={`Transaction Hash: ${transactionReceipt.value.value.hash}`} title='Tranaction Submitted' /> : null}
 		</div>
 	)

--- a/app/ts/components/Transfer.tsx
+++ b/app/ts/components/Transfer.tsx
@@ -162,7 +162,7 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 		}
 
 		if (selectedNft.value.type === 'ERC1155' && transferAmount.value) {
-			const txRequestPromise = transferERC1155(selectedNft.value, serialize(EthereumAddress, provider.value.walletAddress), recipientAddress.value, transferAmount.value, provider.value.provider);
+			const txRequestPromise = transferERC1155(selectedNft.value, serialize(EthereumAddress, provider.value.walletAddress), recipientAddress.value, transferAmount.value, provider.value.provider)
 			return waitForTransaction(() => txRequestPromise)
 		}
 	}
@@ -199,13 +199,13 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 				</div>
 			) : null}
 			<BlockieTextInput value={recipientInput} label='Recipient Address' warn={showWarn.value.recipient} placeholder='0x133...789' />
-			{warning.value ? <SingleNotice variant='warn' description={warning.value} title="Warning" /> : null}
+			{warning.value ? <SingleNotice variant='warn' description={warning.value} title='Warning' /> : null}
 			{provider.value
 				? <Button variant='full' disabled={sendText.value !== 'Send'} onClick={sendTransfer}>{sendText.value}</Button>
 				: <Button variant='full' onClick={() => connectBrowserProvider(provider, blockInfo)}>Connect Wallet</Button>
 			}
-			{transactionReceipt.value.state === 'rejected' && transactionReceipt.value.error.warning ? <SingleNotice variant='error' description={transactionReceipt.value.error.message} title="Error Sending Transfer" /> : null}
-			{transactionReceipt.value.state === 'resolved' ? <SingleNotice variant='success' description={`Transaction Hash: ${transactionReceipt.value.value.hash}`} title="Tranaction Submitted" /> : null}
+			{transactionReceipt.value.state === 'rejected' && transactionReceipt.value.error.warning ? <SingleNotice variant='error' description={transactionReceipt.value.error.message} title='Error Sending Transfer' /> : null}
+			{transactionReceipt.value.state === 'resolved' ? <SingleNotice variant='success' description={`Transaction Hash: ${transactionReceipt.value.value.hash}`} title='Tranaction Submitted' /> : null}
 		</div>
 	)
 }

--- a/app/ts/components/Transfer.tsx
+++ b/app/ts/components/Transfer.tsx
@@ -1,5 +1,5 @@
 import { batch, Signal, useComputed, useSignal, useSignalEffect } from '@preact/signals'
-import { getAddress } from 'ethers'
+import { getAddress, TransactionResponse } from 'ethers'
 import { connectBrowserProvider, ProviderStore } from '../library/provider.js'
 import { itentifyAddress, ERC721, ERC1155, SupportedToken } from '../library/identifyTokens.js'
 import { BlockInfo } from '../library/types.js'
@@ -10,6 +10,8 @@ import { BlockieTextInput, NumberInput, TextInput, TokenAmountInput } from './In
 import { ItemDetails } from './ItemDetails.js'
 import { EthereumAddress } from '../types/ethereumTypes.js'
 import { serialize } from '../types/wireTypes.js'
+import { useAsyncState } from '../library/asyncState.js'
+import { SingleNotice } from './Notice.js'
 
 export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderStore | undefined>, blockInfo: Signal<BlockInfo> }) => {
 	const selectedNft = useSignal<ERC721 | ERC1155 | undefined>(undefined)
@@ -61,7 +63,6 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 			}
 		})
 	}
-
 
 	useSignalEffect(() => {
 		if (provider.value) {
@@ -125,17 +126,6 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 		}
 		fetchingStates.value = 'fetching'
 		try {
-// <<<<<<< HEAD
-			// const identifiedAddress = await itentifyAddress(address, id, provider.value?.provider, provider.value?.walletAddress)
-			// if (identifiedAddress.address === contractAddress.value && identifiedAddress.inputId === itemId.value) {
-			// 	if (identifiedAddress.type === 'ERC721') {
-			// 		selectedNft.value = identifiedAddress
-
-			// 	} else if (identifiedAddress.type === 'ERC1155') {
-			// 		selectedNft.value = identifiedAddress
-			// 	} else if (identifiedAddress.type === 'ERC20') {
-			// 		warning.value = 'Token address provided is an ERC20 contract'
-// =======
 			const identifiedAssets = await itentifyAddress(address, id, provider.value?.provider, provider.value?.walletAddress)
 			if (identifiedAssets[0].address === contractAddress.value && identifiedAssets[0].inputId === itemId.value) {
 				const supportedTypes = identifiedAssets.filter((token): token is SupportedToken => ['ERC721', 'ERC1155'].includes(token.type))
@@ -160,9 +150,20 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 		}
 	}
 
-	function sendTransfer() {
-		if (selectedNft.value && recipientAddress.value && provider.value && selectedNft.value.type === 'ERC721') transferERC721(selectedNft.value, recipientAddress.value, provider.value.provider)
-		if (selectedNft.value && recipientAddress.value && provider.value && transferAmount.value && selectedNft.value.type === 'ERC1155') transferERC1155(selectedNft.value, serialize(EthereumAddress, provider.value.walletAddress), recipientAddress.value, transferAmount.value, provider.value.provider)
+	const { value: transactionReceipt, waitFor: waitForTransaction } = useAsyncState<TransactionResponse>()
+
+	async function sendTransfer() {
+		if (!selectedNft.value || !recipientAddress.value || !provider.value) return
+
+		if (selectedNft.value.type === 'ERC721') {
+			const txRequestPromise = transferERC721(selectedNft.value, recipientAddress.value, provider.value.provider)
+			return waitForTransaction(() => txRequestPromise)
+		}
+
+		if (selectedNft.value.type === 'ERC1155' && transferAmount.value) {
+			const txRequestPromise = transferERC1155(selectedNft.value, serialize(EthereumAddress, provider.value.walletAddress), recipientAddress.value, transferAmount.value, provider.value.provider);
+			return waitForTransaction(() => txRequestPromise)
+		}
 	}
 
 	return (
@@ -197,20 +198,13 @@ export const Transfer = ({ provider, blockInfo }: { provider: Signal<ProviderSto
 				</div>
 			) : null}
 			<BlockieTextInput value={recipientInput} label='Recipient Address' warn={showWarn.value.recipient} placeholder='0x133...789' />
-			{warning.value ? (
-				<div class='flex items-center items-center border border-orange-400/50 bg-orange-400/10 px-4 py-2 gap-4'>
-					ⓘ
-					<div class='py-3 flex-grow'>
-						<div>
-							<strong>Warning:</strong> {warning}
-						</div>
-					</div>
-				</div>
-			) : null}
+			{warning.value ? <SingleNotice variant='warn' description={warning.value} title="Warning" /> : null}
 			{provider.value
 				? <Button variant='full' disabled={sendText.value !== 'Send'} onClick={sendTransfer}>{sendText.value}</Button>
 				: <Button variant='full' onClick={() => connectBrowserProvider(provider, blockInfo)}>Connect Wallet</Button>
 			}
+			{transactionReceipt.value.state === 'rejected' ? <SingleNotice variant='error' description={transactionReceipt.value.error.message} title="Error Sending Transfer" /> : null}
+			{transactionReceipt.value.state === 'resolved' ? <SingleNotice variant='success' description={`Transaction Hash: ${transactionReceipt.value.value.hash}`} title="Tranaction Submitted" /> : null}
 		</div>
 	)
 }

--- a/app/ts/library/asyncState.ts
+++ b/app/ts/library/asyncState.ts
@@ -2,11 +2,11 @@ import { Signal, useSignal } from '@preact/signals'
 export type Inactive = { state: 'inactive' }
 export type Pending = { state: 'pending' }
 export type Resolved<T> = { state: 'resolved'; value: T }
-export type Rejected = { state: 'rejected'; error: Error }
-export type AsyncProperty<T> = Inactive | Pending | Resolved<T> | Rejected
-export type AsyncState<T> = { value: Signal<AsyncProperty<T>>; waitFor: (resolver: () => Promise<T>) => void; reset: () => void }
+export type Rejected<E> = { state: 'rejected'; error: E }
+export type AsyncProperty<T, E> = Inactive | Pending | Resolved<T> | Rejected<E>
+export type AsyncState<T, E> = { value: Signal<AsyncProperty<T, E>>; waitFor: (resolver: () => Promise<T>) => void; reset: () => void }
 
-export function useAsyncState<T>(): AsyncState<T> {
+export function useAsyncState<T, E = unknown>(): AsyncState<T, E> {
 	function getCaptureAndCancelOthers() {
 		// delete previously captured signal so any pending async work will no-op when they resolve
 		delete captureContainer.peek().result
@@ -18,7 +18,7 @@ export function useAsyncState<T>(): AsyncState<T> {
 	async function activate(resolver: () => Promise<T>) {
 		const capture = getCaptureAndCancelOthers()
 		// we need to read the property out of the capture every time we look at it, in case it is deleted asynchronously
-		function setCapturedResult(newResult: AsyncProperty<T>) {
+		function setCapturedResult(newResult: AsyncProperty<T, E>) {
 			const result = capture.result
 			if (result === undefined) return
 			result.value = newResult
@@ -30,7 +30,7 @@ export function useAsyncState<T>(): AsyncState<T> {
 			const resolvedState = { state: 'resolved' as const, value: resolvedValue }
 			setCapturedResult(resolvedState)
 		} catch (unknownError: unknown) {
-			const error = unknownError instanceof Error ? unknownError : typeof unknownError === 'string' ? new Error(unknownError) : new Error(`Unknown error occurred.\n${JSON.stringify(unknownError)}`)
+			const error = unknownError as E
 			const rejectedState = { state: 'rejected' as const, error }
 			setCapturedResult(rejectedState)
 		}
@@ -42,8 +42,8 @@ export function useAsyncState<T>(): AsyncState<T> {
 		result.value = { state: 'inactive' }
 	}
 
-	const result = useSignal<AsyncProperty<T>>({ state: 'inactive' })
-	const captureContainer = useSignal<{ result?: Signal<AsyncProperty<T>> }>({})
+	const result = useSignal<AsyncProperty<T, E>>({ state: 'inactive' })
+	const captureContainer = useSignal<{ result?: Signal<AsyncProperty<T, E>> }>({})
 
 	return { value: result, waitFor: resolver => activate(resolver), reset }
 }

--- a/app/ts/library/humanEthersErrors.ts
+++ b/app/ts/library/humanEthersErrors.ts
@@ -41,62 +41,62 @@ export function humanReadableEthersError(error: unknown): HumanReadableEthersErr
 		switch (error.code) {
 				// Generic Errors
 			case 'UNKNOWN_ERROR':
-				console.error("Found UNKNOWN_ERROR error: ", error)
+				console.error('Found UNKNOWN_ERROR error: ', error)
 				return { warning: true, message: `Unknown Error: ${typeof error === 'string' ? error : JSON.stringify(error)}` }
 			case 'NOT_IMPLEMENTED':
-				console.error("Found NOT_IMPLEMENTED Error: ", error)
-				return { warning: true, message: `Error with EthersJS: "${error.info ? JSON.stringify(error.info) : ''}". This is a bug and you should report it.`};
+				console.error('Found NOT_IMPLEMENTED Error: ', error)
+				return { warning: true, message: `Error with EthersJS: "${error.info ? JSON.stringify(error.info) : ''}". This is a bug and you should report it.`}
 			case 'UNSUPPORTED_OPERATION':
-				return { warning: true, message: `Attempted to execute an unsupported operation: "${error.info ? JSON.stringify(error.info) : ''}". This is a bug and you should report it.` };
+				return { warning: true, message: `Attempted to execute an unsupported operation: "${error.info ? JSON.stringify(error.info) : ''}". This is a bug and you should report it.` }
 			case 'SERVER_ERROR':
-				return { warning: true, message: `Could not communicate with server. ${error.info ? JSON.stringify(error.info) : ''}` };
+				return { warning: true, message: `Could not communicate with server. ${error.info ? JSON.stringify(error.info) : ''}` }
 			case 'TIMEOUT':
-				return { warning: true, message: `Timeout during action "${error.operation}". ${error.reason}` };
+				return { warning: true, message: `Timeout during action "${error.operation}". ${error.reason}` }
 			case 'BAD_DATA':
-				return { warning: true, message: `EthersJS tried failed to understand this value: ${JSON.stringify(error.value)}. This is likely a bug and you should report it.` };
+				return { warning: true, message: `EthersJS tried failed to understand this value: ${JSON.stringify(error.value)}. This is likely a bug and you should report it.` }
 			case 'CANCELLED':
-				return { warning: false, message: `Request was canceled by app. ${error.info ? JSON.stringify(error.info) : ''}` };
+				return { warning: false, message: `Request was canceled by app. ${error.info ? JSON.stringify(error.info) : ''}` }
 			// Operational Errors
 			case 'BUFFER_OVERRUN':
-				return { warning: true, message: `Buffer overrun. This likely a bug and you should report it. ${error.info ? JSON.stringify(error.info): ''}` };
+				return { warning: true, message: `Buffer overrun. This likely a bug and you should report it. ${error.info ? JSON.stringify(error.info): ''}` }
 			case 'NUMERIC_FAULT':
-				return { warning: true, message: `Failed to ${error.operation}. ${error.fault} with value ${error.value}` };
+				return { warning: true, message: `Failed to ${error.operation}. ${error.fault} with value ${error.value}` }
 			// Argument Errors
 			case 'INVALID_ARGUMENT':
-				return { warning: true, message: `EthersJS received an invalid argument, "${error.argument}" with value ${JSON.stringify(error.value)}. This is a bug and you should report it. ${error.stack ?? ''}` };
+				return { warning: true, message: `EthersJS received an invalid argument, "${error.argument}" with value ${JSON.stringify(error.value)}. This is a bug and you should report it. ${error.stack ?? ''}` }
 			case 'MISSING_ARGUMENT':
-				return { warning: true, message: `EthersJS expected ${error.count} arguments and received ${error.expectedCount}. This is a bug and you should report it. ${error.stack ?? ''}` };
+				return { warning: true, message: `EthersJS expected ${error.count} arguments and received ${error.expectedCount}. This is a bug and you should report it. ${error.stack ?? ''}` }
 			case 'UNEXPECTED_ARGUMENT':
-				return { warning: true, message: `EthersJS received too many arguments. This is a bug and you should report it. ${error.stack ?? ''}` };
+				return { warning: true, message: `EthersJS received too many arguments. This is a bug and you should report it. ${error.stack ?? ''}` }
 			// Blockchain Errors
 			case 'CALL_EXCEPTION':
 				if (error.receipt) {
 					return { warning: true, message: `Transaction was included in block #${error.receipt.blockNumber} but reverted${error.reason ? ` with error: ${error.reason}`: ''}` }
 				} else {
-					return { warning: true, message: error.reason ? `Transaction will fail. Call exeception during ${error.action}: ${error.reason}`: `The transaction will revert. ${error.reason ?? ''}` };
+					return { warning: true, message: error.reason ? `Transaction will fail. Call exeception during ${error.action}: ${error.reason}`: `The transaction will revert. ${error.reason ?? ''}` }
 				}
 			case 'INSUFFICIENT_FUNDS':
-				return { warning: true, message: `Account ${error.transaction.from} does not have enough funds for this transaction.` };
+				return { warning: true, message: `Account ${error.transaction.from} does not have enough funds for this transaction.` }
 			case 'NONCE_EXPIRED':
-				return { warning: true, message: `Account ${error.transaction.from} has already made a transaction with the same nonce. Call the transaction again with a new nonce.` }; // Whats human readable / user friendly here?
+				return { warning: true, message: `Account ${error.transaction.from} has already made a transaction with the same nonce. Call the transaction again with a new nonce.` } // Whats human readable / user friendly here?
 			case 'REPLACEMENT_UNDERPRICED':
-				return { warning: true, message: `Unimplemented ${error.code}` };
+				return { warning: true, message: `Unimplemented ${error.code}` }
 			case 'TRANSACTION_REPLACED':
-				return { warning: true, message: `Unimplemented ${error.code}` };
+				return { warning: true, message: `Unimplemented ${error.code}` }
 			case 'UNCONFIGURED_NAME':
-				return { warning: true, message: `Could not find ${error.value}. This ENS address may not be registered.` };
+				return { warning: true, message: `Could not find ${error.value}. This ENS address may not be registered.` }
 			case 'OFFCHAIN_FAULT':
-				return { warning: true, message: `Offchain CCIP Error: ${error.reason}` };
+				return { warning: true, message: `Offchain CCIP Error: ${error.reason}` }
 			// User Interaction Errors
 			case 'ACTION_REJECTED':
-				return { warning: false, message: 'User rejected the request' };
+				return { warning: false, message: 'User rejected the request' }
 			default:
-				console.error("Found UNKNOWN_ERROR error: ", error)
+				console.error('Found UNKNOWN_ERROR error: ', error)
 				return { warning: true, message: `Unknown error: ${JSON.stringify(error)}` }
 		}
 	} else {
 		// string, code, extra?, fallback
-		console.error("Found unknown error: ", error)
+		console.error('Found unknown error: ', error)
 		return { warning: true, message: `Unknown Error: ${typeof error === 'string' ? error : JSON.stringify(error)}` }
 	}
 }

--- a/app/ts/library/humanEthersErrors.ts
+++ b/app/ts/library/humanEthersErrors.ts
@@ -78,11 +78,11 @@ export function humanReadableEthersError(error: unknown): HumanReadableEthersErr
 			case 'INSUFFICIENT_FUNDS':
 				return { warning: true, message: `Account ${error.transaction.from} does not have enough funds for this transaction.` }
 			case 'NONCE_EXPIRED':
-				return { warning: true, message: `Account ${error.transaction.from} has already made a transaction with the same nonce. Call the transaction again with a new nonce.` } // Whats human readable / user friendly here?
+				return { warning: true, message: `The transaction from ${error.transaction.from} got replaced by a transaction with the same nonce.` }
 			case 'REPLACEMENT_UNDERPRICED':
-				return { warning: true, message: `Unimplemented ${error.code}` }
+				return { warning: true, message: `The replacement transaction is underpriced.` }
 			case 'TRANSACTION_REPLACED':
-				return { warning: true, message: `Unimplemented ${error.code}` }
+				return { warning: true, message: `The transaction got replaced by a transaction with the same nonce` }
 			case 'UNCONFIGURED_NAME':
 				return { warning: true, message: `Could not find ${error.value}. This ENS address may not be registered.` }
 			case 'OFFCHAIN_FAULT':
@@ -91,8 +91,8 @@ export function humanReadableEthersError(error: unknown): HumanReadableEthersErr
 			case 'ACTION_REJECTED':
 				return { warning: false, message: 'User rejected the request' }
 			default:
-				console.error('Found UNKNOWN_ERROR error: ', error)
-				return { warning: true, message: `Unknown error: ${JSON.stringify(error)}` }
+				console.error('Found unknown error: ', error)
+				return { warning: true, message: `Unknown Error: ${typeof error === 'string' ? error : JSON.stringify(error)}` }
 		}
 	} else {
 		// string, code, extra?, fallback

--- a/app/ts/library/humanEthersErrors.ts
+++ b/app/ts/library/humanEthersErrors.ts
@@ -1,0 +1,102 @@
+import { ActionRejectedError, NetworkError, TimeoutError, CancelledError, NumericFaultError, MissingArgumentError, CallExceptionError, TransactionReplacedError, ReplacementUnderpricedError, UnconfiguredNameError, UnexpectedArgumentError, InvalidArgumentError, BufferOverrunError, BadDataError, ServerError, NotImplementedError, UnknownError, UnsupportedOperationError, InsufficientFundsError, NonceExpiredError, OffchainFaultError } from 'ethers'
+
+type ETHERS_ERROR = (UnknownError & { code: 'UNKNOWN_ERROR' })
+  | (NotImplementedError & { code: 'NOT_IMPLEMENTED' })
+  | (UnsupportedOperationError & { code: 'UNSUPPORTED_OPERATION' })
+  | (NetworkError & { code: 'NETWORK_ERROR' })
+  | (ServerError & { code: 'SERVER_ERROR' })
+  | (TimeoutError & { code: 'TIMEOUT' })
+  | (BadDataError & { code: 'BAD_DATA' })
+  | (CancelledError & { code: 'CANCELLED' })
+  | (BufferOverrunError & { code: 'BUFFER_OVERRUN' })
+  | (NumericFaultError & { code: 'NUMERIC_FAULT' })
+  | (InvalidArgumentError & { code: 'INVALID_ARGUMENT' })
+  | (MissingArgumentError & { code: 'MISSING_ARGUMENT' })
+  | (UnexpectedArgumentError & { code: 'UNEXPECTED_ARGUMENT' })
+  | (CallExceptionError & { code: 'CALL_EXCEPTION' })
+  | (InsufficientFundsError & { code: 'INSUFFICIENT_FUNDS' })
+  | (NonceExpiredError & { code: 'NONCE_EXPIRED' })
+  | (OffchainFaultError & { code: 'OFFCHAIN_FAULT' })
+  | (ReplacementUnderpricedError & { code: 'REPLACEMENT_UNDERPRICED' })
+  | (TransactionReplacedError & { code: 'TRANSACTION_REPLACED' })
+  | (UnconfiguredNameError & { code: 'UNCONFIGURED_NAME' })
+  | (ActionRejectedError & { code: 'ACTION_REJECTED' })
+const ETHERS_ERROR_CODES = [ 'UNKNOWN_ERROR', 'NOT_IMPLEMENTED', 'UNSUPPORTED_OPERATION', 'NETWORK_ERROR', 'SERVER_ERROR', 'TIMEOUT', 'BAD_DATA', 'CANCELLED', 'BUFFER_OVERRUN', 'NUMERIC_FAULT', 'INVALID_ARGUMENT', 'MISSING_ARGUMENT', 'UNEXPECTED_ARGUMENT', 'CALL_EXCEPTION', 'INSUFFICIENT_FUNDS', 'NONCE_EXPIRED', 'OFFCHAIN_FAULT', 'REPLACEMENT_UNDERPRICED', 'TRANSACTION_REPLACED', 'UNCONFIGURED_NAME', 'ACTION_REJECTED' ] as const
+type ETHERS_ERROR_CODES = typeof ETHERS_ERROR_CODES[number]
+
+export function isEthersError(error: unknown): error is ETHERS_ERROR {
+	if (typeof error !== 'object') return false
+	if (error === null) return false
+	if (!('code' in error)) return false
+	const code = error.code
+	if (typeof code !== 'string') return false
+	if (!ETHERS_ERROR_CODES.includes(code as ETHERS_ERROR_CODES)) return false
+	return true
+}
+
+export type HumanReadableEthersError = { message: string, warning: boolean }
+
+export function humanReadableEthersError(error: unknown): HumanReadableEthersError {
+	if (isEthersError(error)) {
+		switch (error.code) {
+				// Generic Errors
+			case 'UNKNOWN_ERROR':
+				console.error("Found UNKNOWN_ERROR error: ", error)
+				return { warning: true, message: `Unknown Error: ${typeof error === 'string' ? error : JSON.stringify(error)}` }
+			case 'NOT_IMPLEMENTED':
+				console.error("Found NOT_IMPLEMENTED Error: ", error)
+				return { warning: true, message: `Error with EthersJS: "${error.info ? JSON.stringify(error.info) : ''}". This is a bug and you should report it.`};
+			case 'UNSUPPORTED_OPERATION':
+				return { warning: true, message: `Attempted to execute an unsupported operation: "${error.info ? JSON.stringify(error.info) : ''}". This is a bug and you should report it.` };
+			case 'SERVER_ERROR':
+				return { warning: true, message: `Could not communicate with server. ${error.info ? JSON.stringify(error.info) : ''}` };
+			case 'TIMEOUT':
+				return { warning: true, message: `Timeout during action "${error.operation}". ${error.reason}` };
+			case 'BAD_DATA':
+				return { warning: true, message: `EthersJS tried failed to understand this value: ${JSON.stringify(error.value)}. This is likely a bug and you should report it.` };
+			case 'CANCELLED':
+				return { warning: false, message: `Request was canceled by app. ${error.info ? JSON.stringify(error.info) : ''}` };
+			// Operational Errors
+			case 'BUFFER_OVERRUN':
+				return { warning: true, message: `Buffer overrun. This likely a bug and you should report it. ${error.info ? JSON.stringify(error.info): ''}` };
+			case 'NUMERIC_FAULT':
+				return { warning: true, message: `Failed to ${error.operation}. ${error.fault} with value ${error.value}` };
+			// Argument Errors
+			case 'INVALID_ARGUMENT':
+				return { warning: true, message: `EthersJS received an invalid argument, "${error.argument}" with value ${JSON.stringify(error.value)}. This is a bug and you should report it. ${error.stack ?? ''}` };
+			case 'MISSING_ARGUMENT':
+				return { warning: true, message: `EthersJS expected ${error.count} arguments and received ${error.expectedCount}. This is a bug and you should report it. ${error.stack ?? ''}` };
+			case 'UNEXPECTED_ARGUMENT':
+				return { warning: true, message: `EthersJS received too many arguments. This is a bug and you should report it. ${error.stack ?? ''}` };
+			// Blockchain Errors
+			case 'CALL_EXCEPTION':
+				if (error.receipt) {
+					return { warning: true, message: `Transaction was included in block #${error.receipt.blockNumber} but reverted${error.reason ? ` with error: ${error.reason}`: ''}` }
+				} else {
+					return { warning: true, message: error.reason ? `Transaction will fail. Call exeception during ${error.action}: ${error.reason}`: `The transaction will revert. ${error.reason ?? ''}` };
+				}
+			case 'INSUFFICIENT_FUNDS':
+				return { warning: true, message: `Account ${error.transaction.from} does not have enough funds for this transaction.` };
+			case 'NONCE_EXPIRED':
+				return { warning: true, message: `Account ${error.transaction.from} has already made a transaction with the same nonce. Call the transaction again with a new nonce.` }; // Whats human readable / user friendly here?
+			case 'REPLACEMENT_UNDERPRICED':
+				return { warning: true, message: `Unimplemented ${error.code}` };
+			case 'TRANSACTION_REPLACED':
+				return { warning: true, message: `Unimplemented ${error.code}` };
+			case 'UNCONFIGURED_NAME':
+				return { warning: true, message: `Could not find ${error.value}. This ENS address may not be registered.` };
+			case 'OFFCHAIN_FAULT':
+				return { warning: true, message: `Offchain CCIP Error: ${error.reason}` };
+			// User Interaction Errors
+			case 'ACTION_REJECTED':
+				return { warning: false, message: 'User rejected the request' };
+			default:
+				console.error("Found UNKNOWN_ERROR error: ", error)
+				return { warning: true, message: `Unknown error: ${JSON.stringify(error)}` }
+		}
+	} else {
+		// string, code, extra?, fallback
+		console.error("Found unknown error: ", error)
+		return { warning: true, message: `Unknown Error: ${typeof error === 'string' ? error : JSON.stringify(error)}` }
+	}
+}

--- a/app/ts/library/transactions.tsx
+++ b/app/ts/library/transactions.tsx
@@ -7,7 +7,7 @@ import { ERC1155, ERC721 } from './identifyTokens.js'
 export async function transferERC721(nft: ERC721, recipient: string, provider: BrowserProvider): Promise<TransactionResponse> {
 	const contract = new Contract(nft.address, ERC721ABI, await provider.getSigner())
 	try {
-		return await contract.transferFrom(nft.owner, recipient, nft.id);
+		return await contract.transferFrom(nft.owner, recipient, nft.id)
 	} catch (ethersError) {
 		throw humanReadableEthersError(ethersError)
 	}
@@ -16,7 +16,7 @@ export async function transferERC721(nft: ERC721, recipient: string, provider: B
 export async function transferERC1155(nft: ERC1155, from: string, recipient: string, amount: bigint, provider: BrowserProvider): Promise<TransactionResponse> {
 	const contract = new Contract(nft.address, ERC1155ABI, await provider.getSigner())
 	try {
-		return await contract.safeTransferFrom(from, recipient, nft.id, amount, "0x");
+		return await contract.safeTransferFrom(from, recipient, nft.id, amount, "0x")
 	} catch (ethersError) {
 		throw humanReadableEthersError(ethersError)
 	}

--- a/app/ts/library/transactions.tsx
+++ b/app/ts/library/transactions.tsx
@@ -1,23 +1,14 @@
 import { TransactionResponse } from 'ethers';
 import { Contract, BrowserProvider } from 'ethers'
 import { ERC1155ABI, ERC721ABI } from './abi.js'
-import { humanReadableEthersError } from './humanEthersErrors.js';
 import { ERC1155, ERC721 } from './identifyTokens.js'
 
 export async function transferERC721(nft: ERC721, recipient: string, provider: BrowserProvider): Promise<TransactionResponse> {
 	const contract = new Contract(nft.address, ERC721ABI, await provider.getSigner())
-	try {
-		return await contract.transferFrom(nft.owner, recipient, nft.id)
-	} catch (ethersError) {
-		throw humanReadableEthersError(ethersError)
-	}
+	return await contract.transferFrom(nft.owner, recipient, nft.id)
 }
 
 export async function transferERC1155(nft: ERC1155, from: string, recipient: string, amount: bigint, provider: BrowserProvider): Promise<TransactionResponse> {
 	const contract = new Contract(nft.address, ERC1155ABI, await provider.getSigner())
-	try {
-		return await contract.safeTransferFrom(from, recipient, nft.id, amount, "0x")
-	} catch (ethersError) {
-		throw humanReadableEthersError(ethersError)
-	}
+	return await contract.safeTransferFrom(from, recipient, nft.id, amount, "0x")
 }

--- a/app/ts/library/transactions.tsx
+++ b/app/ts/library/transactions.tsx
@@ -1,15 +1,14 @@
+import { TransactionResponse } from 'ethers';
 import { Contract, BrowserProvider } from 'ethers'
 import { ERC1155ABI, ERC721ABI } from './abi.js'
 import { ERC1155, ERC721 } from './identifyTokens.js'
 
-export async function transferERC721(nft: ERC721, recipient: string, provider: BrowserProvider) {
+export async function transferERC721(nft: ERC721, recipient: string, provider: BrowserProvider): Promise<TransactionResponse> {
 	const contract = new Contract(nft.address, ERC721ABI, await provider.getSigner())
-	const tx = await contract.transferFrom(nft.owner, recipient, nft.id);
-	await tx.wait()
+	return await contract.transferFrom(nft.owner, recipient, nft.id);
 }
 
-export async function transferERC1155(nft: ERC1155, from: string, recipient: string, amount: bigint, provider: BrowserProvider) {
+export async function transferERC1155(nft: ERC1155, from: string, recipient: string, amount: bigint, provider: BrowserProvider): Promise<TransactionResponse> {
 	const contract = new Contract(nft.address, ERC1155ABI, await provider.getSigner())
-	const tx = await contract.safeTransferFrom(from, recipient, nft.id, amount, "0x");
-	await tx.wait()
+	return await contract.safeTransferFrom(from, recipient, nft.id, amount, "0x");
 }

--- a/app/ts/library/transactions.tsx
+++ b/app/ts/library/transactions.tsx
@@ -1,14 +1,23 @@
 import { TransactionResponse } from 'ethers';
 import { Contract, BrowserProvider } from 'ethers'
 import { ERC1155ABI, ERC721ABI } from './abi.js'
+import { humanReadableEthersError } from './humanEthersErrors.js';
 import { ERC1155, ERC721 } from './identifyTokens.js'
 
 export async function transferERC721(nft: ERC721, recipient: string, provider: BrowserProvider): Promise<TransactionResponse> {
 	const contract = new Contract(nft.address, ERC721ABI, await provider.getSigner())
-	return await contract.transferFrom(nft.owner, recipient, nft.id);
+	try {
+		return await contract.transferFrom(nft.owner, recipient, nft.id);
+	} catch (ethersError) {
+		throw humanReadableEthersError(ethersError)
+	}
 }
 
 export async function transferERC1155(nft: ERC1155, from: string, recipient: string, amount: bigint, provider: BrowserProvider): Promise<TransactionResponse> {
 	const contract = new Contract(nft.address, ERC1155ABI, await provider.getSigner())
-	return await contract.safeTransferFrom(from, recipient, nft.id, amount, "0x");
+	try {
+		return await contract.safeTransferFrom(from, recipient, nft.id, amount, "0x");
+	} catch (ethersError) {
+		throw humanReadableEthersError(ethersError)
+	}
 }


### PR DESCRIPTION
- Added cards to show success or errors when users submit transfer transactions
- Errors are not human readable yet, so will need to build some functions to parse and display the possible error types

Ethers has distinct types of errors (https://docs.ethers.org/v6/api/utils/errors/#ErrorCode), so we just need to handle each type of error. This also needs to be done in [Lunaria](https://github.com/DarkFlorist/lunaria/issues/169) also.

Fixes #24 