### PR TITLE
Fix missing install script in publishing to github pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,12 +9,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 'v18.13.0'
           registry-url: 'https://registry.npmjs.org'
       - name: Install and Build
         run: |
+          npm ci
           npm run vendor
           npm run styles
           npm run build


### PR DESCRIPTION
Since changing the vendoring script, which previously included npm installation, the script is now missing node modules.

To remove build warnings, [action/setup-node](https://github.com/actions/setup-node) was also updated to v4